### PR TITLE
Ft get tags

### DIFF
--- a/data/models/article-model.js
+++ b/data/models/article-model.js
@@ -268,6 +268,17 @@ async function getArticlesById(id) {
   }
 }
 
+async function findAllTags() {
+  try {
+    const tags = await db("tags")
+      .select("name", "id", "articleId")
+      .distinct();
+    return tags;
+  } catch (error) {
+    console.log(error);
+  }
+}
+
 module.exports = {
   addArticleLike,
   getLikeCountByArticleId,
@@ -279,5 +290,6 @@ module.exports = {
   addTag,
   getArticleTags,
   getArticlesById,
-  addCover
+  addCover,
+  findAllTags
 };

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -42,6 +42,16 @@ router.get("/", loggedIn, async (req, res, next) => {
   }
 });
 
+router.get("/tags", async (req, res) => {
+  try {
+    const tags = await service.getAllTags();
+    res.status(200).json(tags)
+  }
+  catch(error) {
+    res.status(500).json({error: error.message})
+  }
+})
+
 // router.post("/uploadCover", async (req, res) => {
 //   let form = new formidable.IncomingForm();
 //   form.parse(req, async function(err, fields, files) {

--- a/services/articles.js
+++ b/services/articles.js
@@ -75,6 +75,11 @@ async function addTag(tag, id) {
   return response;
 }
 
+async function getAllTags() {
+  const response = await articles.findAllTags();
+  return response;
+}
+
 async function uploadFile(image) {
   try {
     const fileContent = fs.readFileSync(image.path);
@@ -130,5 +135,6 @@ module.exports = {
   uploadFile,
   getArticleInfo,
   getArticleLikeCount,
-  addNewCover
+  addNewCover,
+  getAllTags
 };


### PR DESCRIPTION
# Description

GET /api/articles/tags ednpoint

Add new endpoint to get all tags back from db (distinct by tag name to remove duplicate occurrences in response). For use in user profile component on frontend to render list of all potential interests they can choose from. If this was done by pulling all interests from the interests table and allowing the user to choose from there it wouldn't account for article tags that no users have registered an interest in.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


## Change status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

Tested on Postman and within Edit Profile component on frontend.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [ ] I have run the app using my feature and ensured that no functionality is broken
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
